### PR TITLE
fixes show_nav querystring flag

### DIFF
--- a/app/controllers/floors_controller.rb
+++ b/app/controllers/floors_controller.rb
@@ -75,7 +75,8 @@ class FloorsController < ApplicationController
   end
 
   def show_navbar
-    @show_navbar = params[:show_navbar] || true
+    params[:show_navbar] ||= '1'
+    @show_navbar = params[:show_navbar] == '1'
   end
 
   def set_floor


### PR DESCRIPTION
fixes #174 

Defaults to showing the nav unless passed anything other than "1" on the querystring