### PR TITLE
enables virtual keyboard for only the kiosks

### DIFF
--- a/app/views/shared/_search_nav.html.erb
+++ b/app/views/shared/_search_nav.html.erb
@@ -13,20 +13,24 @@
   </div>
 </div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-<link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.12.0/themes/ui-lightness/jquery-ui.css" rel="stylesheet">
-<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
-<%= javascript_include_tag 'application' %>
-<script type='text/javascript'>
-  $('#search').keyboard({
-    accepted: function(e, keyboard, el) {
-      $('.search-button').click();
-    },
-    beforeVisible: function(e, keyboard, el) {
-      $('.search-button').hide();
-    },
-    beforeClose: function(e, keyboard, el) {
+<%# Don't render the virtual keyboard for clients other than the kiosks, and try to allow for a range
+    of truthy/falsey params that might be passed on the querystring. %>
+<% if params[:kiosk].present? && ActiveRecord::Type::Boolean.new.cast(params[:kiosk]) %>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+  <link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.12.0/themes/ui-lightness/jquery-ui.css" rel="stylesheet">
+  <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
+  <%= javascript_include_tag 'application' %>
+  <script type='text/javascript'>
+    $('#search').keyboard({
+      accepted: function(e, keyboard, el) {
+        $('.search-button').click();
+      },
+      beforeVisible: function(e, keyboard, el) {
+        $('.search-button').hide();
+      },
+      beforeClose: function(e, keyboard, el) {
       $('.search-button').show();
-    }
-  });
-</script>
+      }
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
fixes #291 
Only enable/use the virtual keyboard when the param `kiosk` is present and truthy.. it really doesn't make sense for non-kiosk usage.