### PR TITLE
Adds quick link functionality to legend

### DIFF
--- a/app/controllers/floors_controller.rb
+++ b/app/controllers/floors_controller.rb
@@ -141,6 +141,7 @@ class FloorsController < ApplicationController
     results << Location.search_for(search_params)
     results << Tag.search_for(search_params).has_location
     results << Trait.search_for(search_params).has_location
+    results << Icon.search_for(search_params).select{ |i| !i.location_ids.nil? }
     results.flatten.uniq
   end
 
@@ -157,6 +158,7 @@ class FloorsController < ApplicationController
     locations << sr.select { |r| r.is_a?(Trait) && r.value.casecmp('yes').zero? }.map{ |r| r.locations.to_a }
     locations << sr.select { |r| r.is_a?(Tag) && !r.location.nil? }.map{ |r| r.location }
     locations << sr.select { |r| r.is_a?(Location) }
+    locations << sr.select { |r| r.is_a?(Icon) }.map{ |r| r.locations.to_a }
     locations.flatten.uniq
   end
 

--- a/app/controllers/floors_controller.rb
+++ b/app/controllers/floors_controller.rb
@@ -141,7 +141,7 @@ class FloorsController < ApplicationController
     results << Location.search_for(search_params)
     results << Tag.search_for(search_params).has_location
     results << Trait.search_for(search_params).has_location
-    results << Icon.search_for(search_params).select{ |i| !i.location_ids.nil? }
+    results << Icon.search_for(search_params).has_locations
     results.flatten.uniq
   end
 

--- a/app/javascript/components/LegendListElement.jsx
+++ b/app/javascript/components/LegendListElement.jsx
@@ -1,6 +1,15 @@
 import React from "react"
 import PropTypes from "prop-types"
 class LegendListElement extends React.Component {
+
+  build_search_url = (icon_name) => {
+    if (window.location.href.includes("search")){
+      return window.location.href.replace(/(search=).*?(&|$)/,'$1' + icon_name.replace(" ", "+") + '$2');
+    } else {
+      return window.location.href.toString() + '?search=' + icon_name.replace(" ", "+") + '&commit=Search'
+    }
+  }
+
   render() {
     return (<li>
               <div className="container">
@@ -9,7 +18,7 @@ class LegendListElement extends React.Component {
                 </div>
                 <div className="row">
                   <div className="legend_padding">
-                    { this.props.icon_name }
+                    <a href={this.build_search_url(this.props.icon_name)}> { this.props.icon_name } </a>
                   </div>
                 </div>
               </div>

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,9 +1,12 @@
 class Icon < ApplicationRecord
   scope :ordered, -> { order(:name) }
+  scope :has_location, -> { where.not(location_ids: nil) }
   has_many :location_icons
   has_many :locations, through: :location_icons
 
   has_attached_file :icon_image
+
+  scoped_search on: [:name]
 
   validates_attachment_content_type :icon_image, :content_type => ["image/jpg", "image/jpeg", "image/png", "image/gif", "image/svg+xml"]
 

--- a/app/models/icon.rb
+++ b/app/models/icon.rb
@@ -1,6 +1,6 @@
 class Icon < ApplicationRecord
   scope :ordered, -> { order(:name) }
-  scope :has_location, -> { where.not(location_ids: nil) }
+  scope :has_locations, -> { includes(:locations).where.not(locations: { id: nil }) }
   has_many :location_icons
   has_many :locations, through: :location_icons
 


### PR DESCRIPTION
This is my proposed fix for #289 

Currently this requires the icon carry the same name as a specific trait/name of location/tag to do the search properly. This means there would be a coupling between the icons name and specific info about the location. Maybe this is ok? Maybe it will happen naturally? Im not sure. Im willing to revisit this as needed though.

It uses some pretty tricky regex stuff to pick out the search param and the rest of the params using capture groups. And it also makes sure it can pick out the search param even if it is the last param in the url. I also sanitize the icon names to include pluses to make them usable in a uri.

It also accounts if it is a fresh url and appends the search params to it. 