### PR TITLE
added a custom layout for the kiosk keyboard

### DIFF
--- a/app/views/shared/_search_nav.html.erb
+++ b/app/views/shared/_search_nav.html.erb
@@ -22,6 +22,17 @@
   <%= javascript_include_tag 'application' %>
   <script type='text/javascript'>
     $('#search').keyboard({
+      autoAccept: true,
+      layout: 'custom',
+      customLayout: {
+        'normal': [
+          '1 2 3 4 5 6 7 8 9 0 - = {bksp}',
+          'q w e r t y u i o p',
+          'a s d f g h j k l ; \'',
+          'z x c v b n m , .',
+          '{cancel} {space} {accept}'
+        ],
+      },
       accepted: function(e, keyboard, el) {
         $('.search-button').click();
       },
@@ -29,8 +40,9 @@
         $('.search-button').hide();
       },
       beforeClose: function(e, keyboard, el) {
-      $('.search-button').show();
+        $('.search-button').show();
       }
+
     });
   </script>
 <% end %>


### PR DESCRIPTION
Added a custom layout (removing the 'Enter' key) for the virtual keyboard used in kiosk mode, so that it matches the current layout used in the primo search section of the new layout:

![image](https://user-images.githubusercontent.com/3486120/38042166-7913b926-3268-11e8-8ff5-670ce1e1a776.png)

This update is related to item 7 in https://github.com/osulp/kiosks/issues/206