### PR TITLE
Add polygon after save

### DIFF
--- a/app/javascript/components/LocationBox/LocationBox.jsx
+++ b/app/javascript/components/LocationBox/LocationBox.jsx
@@ -267,7 +267,7 @@ class LocationBox extends React.Component {
 
   clickedBox = (e) => {
     let location = this.state.location;
-    if(location.polygonClosed || !location.isNew) {
+    if(location.polygonClosed) {
       return null;
     }
     let mouse = d3.mouse(e);


### PR DESCRIPTION
Fixes #326 

We got multiple requests for this. This is a little dangerous because if a user taps on a location it'll continue to add dots. With more power comes more responsibility? 