### PR TITLE
fixes background highlighting bug

### DIFF
--- a/app/javascript/components/Location.js
+++ b/app/javascript/components/Location.js
@@ -4,7 +4,7 @@ class Location {
     this.id                     = props.id                    || guid;
     this.admin_url              = props.admin_url             || '';
     this.add_location_url       = props.add_location_url      || '';
-    this.background_color       = props.background_color      || 'transparent';
+    this.background_color       = props.background_color      || 'none';
     this.created_at             = props.created_at            || new Date().toISOString();
     this.delete_location_url    = props.delete_location_url   || '';
     this.didSave                = props.deleteSave            || false;
@@ -95,17 +95,16 @@ class Location {
     let color = location.background_color;
     if(is_highlight) {
       switch(color) {
+        case 'transparent':
+        case 'none':
         case '':
           color = location.highlightColor;
-          break;
-        case 'transparent':
-          color = 'none';
           break;
         default:
           color = `#${color}`;
           break;
       }
-      return color;
+      return `${color}`;
     }
     return 'none';
   }

--- a/db/migrate/20180405211415_remove_background_color_default.rb
+++ b/db/migrate/20180405211415_remove_background_color_default.rb
@@ -1,0 +1,5 @@
+class RemoveBackgroundColorDefault < ActiveRecord::Migration[5.1]
+  def change
+    change_column :locations, :background_color, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180404151516) do
+ActiveRecord::Schema.define(version: 20180405211415) do
 
   create_table "floors", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
If a location is a search result `is_highlight == true`, then it either uses its background color for highlighting or the default highlight color.

If a location is not a search result  `is_highlight == false` then set the background color to none.