### PR TITLE
update remove tag from location

### DIFF
--- a/db/migrate/20180404151445_remove_tag_from_location.rb
+++ b/db/migrate/20180404151445_remove_tag_from_location.rb
@@ -1,5 +1,5 @@
 class RemoveTagFromLocation < ActiveRecord::Migration[5.1]
   def change
-    remove_reference :locations, :tag, foreign_key: true
+    remove_reference :locations, :tag, index: true
   end
 end


### PR DESCRIPTION
removing `foreign_key: true` from `RemoveTagFromLocation` to fix:

```
03:26 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
03:28 deploy:migrating
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:migrate
      01 == 20180404151445 RemoveTagFromLocation: migrating ============================
      01 -- remove_reference(:locations, :tag, {:foreign_key=>true})
      01 rake aborted!
      01 StandardError: An error has occurred, all later migrations canceled:
      01
      01 Table 'locations' has no foreign key for {:to_table=>"tags", :column=>"tag_id"}
```