### PR TITLE
updated RemoveTagFromLocation

### DIFF
--- a/db/migrate/20180404151445_remove_tag_from_location.rb
+++ b/db/migrate/20180404151445_remove_tag_from_location.rb
@@ -1,5 +1,7 @@
 class RemoveTagFromLocation < ActiveRecord::Migration[5.1]
   def change
-    remove_reference :locations, :tag, index: true
+    if foreign_key_exists?(:locations, column: :tag_id)
+      remove_reference :locations, :tag, index: true
+    end
   end
 end


### PR DESCRIPTION
Check to see if the foreign key exists before removing the reference and fix:
```
03:26 deploy:migrating
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:migrate
      01 == 20180404151445 RemoveTagFromLocation: migrating ============================
      01 -- remove_reference(:locations, :tag, {:index=>true})
      01 rake aborted!
      01 StandardError: An error has occurred, all later migrations canceled:
      01 
      01 Mysql2::Error: Can't DROP 'tag_id'; check that column/key exists: ALTER TABLE `locations` DROP `tag_id`
```